### PR TITLE
chore: finalize predict screen UI & add doc links

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -156,10 +156,11 @@
           </template>
             
           <template v-if="activeTab === 1">
-            <p>Use the Models API to obtain predictions for one or more stored topical models based on the domains that you selected in your Google Sheets.</p>
+            <p class="center">Use the Models API to obtain predictions for one or more stored topical models based on the domains that you selected in your Google Sheets.</p>
             <br>
             <br>
-            <label for="modelSelect">Select Model(s)</label>
+            <label for="modelSelect"><strong>Select Model(s):</strong></label>
+            <br>
             <br>
             <select id="modelSelect" multiple size="8">
               <option v-for="model in models" v-bind:value="model.id">{{ model.name }}</option>

--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -22,7 +22,7 @@
         text-decoration: underline;
       }
       .tab.active {
-        background-color: white;
+        background-color: snow;
       }
       
       .content {
@@ -71,9 +71,21 @@
         margin: 0 auto;
       }
       
-      .customer-fit-footer, .topical-footer {
+      /* Align footer items vertically according to their differences */
+      .customer-fit-footer, .topical-footer, .lets-go-footer {
         display: flex;
         justify-content: space-between;
+      }
+      .customer-fit-footer, .topical-footer {
+        line-height: 2;
+      }
+      
+      .lets-go-footer {
+        line-height: 0;
+      }
+      
+      .doc-link {
+        font-size: 12px;
       }
 
     </style>
@@ -106,8 +118,8 @@
             <p>3. Prioritize whom you should reach out to for outbound.</p>
             <br>
             <br>
-            <div class="customer-fit-footer">
-              <p><a target="_blank" href="https://help.madkudu.com/en/articles/2966015-get-predictive-scores-of-all-your-leads-directly-in-google-sheets">See documentation</a></p>
+            <div class="lets-go-footer">
+              <p><a class="doc-link" target="_blank" href="https://help.madkudu.com/en/articles/2966015-get-predictive-scores-of-all-your-leads-directly-in-google-sheets">See documentation</a></p>
               <button class="action" onclick="setIsReady()">Let's go!</button>
             </div>
           </template>
@@ -124,7 +136,7 @@
               <input type="radio" name="customerFitModel" value="persons" v-model="customerFitModel" id="personsRadio"><label for="personsRadio">Persons</label>
             </div>
             <br>
-            <p>For more information, please see our <a v-bind:href="'https://developers.madkudu.com/#' + (customerFitModel === 'companies' ? 'companies' : 'persons')">docs</a>.</p>
+            <p class="doc-link">For more information, please see our <a v-bind:href="'https://developers.madkudu.com/#' + (customerFitModel === 'companies' ? 'companies' : 'persons')">docs</a>.</p>
             <br>
             <div class="customer-fit-footer">
               <div>
@@ -132,6 +144,13 @@
                 <label for="insertHeadersCheckbox">Insert headers</label>
               </div>
               <button class="action" v-bind:disabled="isLoading" onclick="runPrediction()">Predict</button>
+            </div>
+            <br>
+            <br>
+            <div class="center doc-link">
+              <a>See demo</a>
+              |
+              <a target="_blank" v-bind:href="'https://developers.madkudu.com/#' + (customerFitModel === 'companies' ? 'companies' : 'persons')">See documentation</a>
             </div>
             <br>
           </template>
@@ -146,7 +165,7 @@
               <option v-for="model in models" v-bind:value="model.id">{{ model.name }}</option>
             </select>
             <br>
-            <p>For more information, please see our <a href="https://madkudu.com">docs</a>.</p>
+            <p class="doc-link">For more information, please see our <a target="_blank" href="https://help.madkudu.com/en/articles/2966015-get-predictive-scores-of-all-your-leads-directly-in-google-sheets>docs">docs</a>.</p>
             <br>
             <div class="topical-footer">
               <div>
@@ -186,10 +205,10 @@
             </div>
             <br>
             <br>
-            <div class="center">
+            <div class="center doc-link">
               <a>See demo</a>
               |
-              <a>See documentation</a>
+              <a target="_blank" href="https://help.madkudu.com/en/articles/2966015-get-predictive-scores-of-all-your-leads-directly-in-google-sheets">See documentation</a>
             </div>
           </template>
 
@@ -201,6 +220,8 @@
             <br>
             <label for="apiKeyInput">API Key</label>
             <br>
+            <a class="doc-link" target="_blank" href="https://help.madkudu.com/en/articles/2966015-get-predictive-scores-of-all-your-leads-directly-in-google-sheets/#installing-the-add-on">How do I get my API key?</a>
+            <br>
             <br>
             <input id="apiKeyInput" placeholder="a349892jalduwie239">
             <br>
@@ -211,8 +232,8 @@
 
       </template>
       
-      <div class="footer">
-        <a onclick="changeApiKey()">API Key</a>
+      <div class="footer doc-link">
+        <a onclick="changeApiKey()">Change API Key</a>
       </div>
       
     </div>
@@ -228,7 +249,7 @@
         el: '#app',
         data: {
           apiKey: null,
-          tabs: ['Customer Fit'],
+          tabs: ['Fit Prediction'],
           activeTab: 0,
           models: [{name:'none'}],
           customerFitModel: 'companies',
@@ -306,7 +327,8 @@
         // make sure the apikey is still valid
         if (app.apiKey) {
           app.models = models
-          if (models.length > 1 && !app.tabs.includes('Topical')) {
+          const hasTopicalModels = models.find(model => model.type === 'topical')
+          if (models.length && hasTopicalModels && !app.tabs.includes('Topical')) {
             app.tabs.push('Topical')
           }
         }


### PR DESCRIPTION
https://app.asana.com/0/1133467873647068/1133467873647096/f
https://app.asana.com/0/1133467873647068/1133467873647098/f

- Finalize UI on "Predict" screen
- Add links to documentation

Other small changes:
- Changed color of active tab because a single white tab looked weird
- Aligned buttons to text in footers
- *Changed way that we get topical models, in order to add topical tab*

![Screenshot 2019-07-31 at 15 46 09](https://user-images.githubusercontent.com/2119692/62225817-73861700-b3b9-11e9-9e48-d7340049fbb6.png)

https://script.google.com/a/macros/madkudu.com/d/1kXr-qBi822GkFUQKPNhd-H0TvCQCKiHC2EVBsMbLvhZfsk6gv50l6rsW/edit
